### PR TITLE
Add fritzpack emoji variants into the unicodeMap

### DIFF
--- a/src/main/java/com/freya02/emojis/Emoji.java
+++ b/src/main/java/com/freya02/emojis/Emoji.java
@@ -182,6 +182,22 @@ public final class Emoji {
 		}
 	}
 
+	/**
+	 * @throws IllegalStateException | when the current unicode is empty
+	 * @return New emoji object of current emoji + fritzpatrick type
+	 */
+	public String unicodeWithFritzpatrick(Fritzpatrick type) {
+		StringBuilder sb = new StringBuilder(unicode);
+
+		if (unicode.codePoints().count() == 0) throw new IllegalStateException("Emoji has no unicode representation.");
+		int firstCodePoint = unicode.codePointAt(0);
+
+		char[] chars = Character.toChars(firstCodePoint);
+		sb.insert(chars.length > 1 ? 2 : 1, type.getUnicode());
+
+		return sb.toString();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -212,26 +228,5 @@ public final class Emoji {
 				", shortcodes=" + shortcodes +
 				", supportsFitzpatrick=" + supportsFitzpatrick +
 				'}';
-	}
-
-	/**
-	 * @throws IllegalStateException | when the current unicode is empty
-	 * @return New emoji object of current emoji + fritzpatrick type
-	 */
-	public Emoji asFritzpatrick(Fritzpatrick type) {
-		StringBuilder sb = new StringBuilder(unicode);
-
-		if (unicode.codePoints().count() == 0) throw new IllegalStateException("Emoji has no unicode representation.");
-		int firstCodePoint = unicode.codePointAt(0);
-
-		char[] chars = Character.toChars(firstCodePoint);
-		sb.insert(chars.length > 1 ? 2 : 1, type.getUnicode());
-
-		return new Emoji(
-				subpage,
-				sb.toString(),
-				List.copyOf(shortcodes),
-				false
-		);
 	}
 }

--- a/src/main/java/com/freya02/emojis/Emoji.java
+++ b/src/main/java/com/freya02/emojis/Emoji.java
@@ -38,14 +38,18 @@ public final class Emoji {
 	 *
 	 * @return The subpage of Emojipedia.org for this emoji
 	 */
-	public String subpage() { return subpage; }
+	public String subpage() {
+		return subpage;
+	}
 
 	/**
 	 * Returns the Unicode for this emoji, such as <code>😂</code>
 	 *
 	 * @return The Unicode for this emoji
 	 */
-	public String unicode() { return unicode; }
+	public String unicode() {
+		return unicode;
+	}
 
 	/**
 	 * Returns the shortcodes for this emoji, such as <code>joy</code>
@@ -53,11 +57,13 @@ public final class Emoji {
 	 *
 	 * @return A list of shortcodes for this emoji
 	 */
-	public List<String> shortcodes() { return shortcodes; }
+	public List<String> shortcodes() {
+		return shortcodes;
+	}
 
 	/**
 	 * Returns whether this emoji supports fitzpatrick (skin color changes)
-	 * 
+	 *
 	 * @return <code>true</code> if the emoji can have a skin tone applied
 	 */
 	public boolean doesSupportFitzpatrick() {
@@ -206,5 +212,16 @@ public final class Emoji {
 				", shortcodes=" + shortcodes +
 				", supportsFitzpatrick=" + supportsFitzpatrick +
 				'}';
+	}
+
+	public Emoji asFritzpatrick(Fritzpatrick type) {
+		StringBuilder sb = new StringBuilder(unicode);
+		sb.insert(2, type.getUnicode());
+		return new Emoji(
+				subpage,
+				sb.toString(),
+				List.copyOf(shortcodes),
+				false
+		);
 	}
 }

--- a/src/main/java/com/freya02/emojis/Emoji.java
+++ b/src/main/java/com/freya02/emojis/Emoji.java
@@ -214,9 +214,19 @@ public final class Emoji {
 				'}';
 	}
 
+	/**
+	 * @throws IllegalStateException | when the current unicode is empty
+	 * @return New emoji object of current emoji + fritzpatrick type
+	 */
 	public Emoji asFritzpatrick(Fritzpatrick type) {
 		StringBuilder sb = new StringBuilder(unicode);
-		sb.insert(2, type.getUnicode());
+
+		if (unicode.codePoints().count() == 0) throw new IllegalStateException("Emoji has no unicode representation.");
+		int firstCodePoint = unicode.codePointAt(0);
+
+		char[] chars = Character.toChars(firstCodePoint);
+		sb.insert(chars.length > 1 ? 2 : 1, type.getUnicode());
+
 		return new Emoji(
 				subpage,
 				sb.toString(),

--- a/src/main/java/com/freya02/emojis/Emojis.java
+++ b/src/main/java/com/freya02/emojis/Emojis.java
@@ -39,15 +39,17 @@ public class Emojis {
 	 * @return An {@link Emoji} with the matching unicode, or <code>null</code> if not found
 	 */
 	public static Emoji ofUnicode(String unicode) {
-		String unFritzedUnicode = unicode;
+		String sanitizedUnicode = unicode
+				.replace("\uFE0E", "")
+				.replace("\uFE0F", "");
 		if (unicode.codePoints().count() > 0) {
 			for (Fritzpatrick fritz : Fritzpatrick.values()) {
-				unFritzedUnicode = unicode.replace(fritz.getUnicode(), "");
-				if (unFritzedUnicode.length() != unicode.length()) break;
+				sanitizedUnicode = unicode.replace(fritz.getUnicode(), "");
+				if (sanitizedUnicode.length() != unicode.length()) break;
 			}
 		}
 
-		return UnicodeHolder.unicodeMap.get(unFritzedUnicode);
+		return UnicodeHolder.unicodeMap.get(sanitizedUnicode);
 	}
 
 	/**
@@ -70,7 +72,10 @@ public class Emojis {
 
 		static {
 			for (Emoji emoji : store.getEmojis()) {
-				final Emoji old = unicodeMap.put(emoji.unicode(), emoji);
+				final String sanitized = emoji.unicode()
+						.replace("\uFE0E", "")
+						.replace("\uFE0F", "");
+				final Emoji old = unicodeMap.put(sanitized, emoji);
 				if (old != null) {
 					LOGGER.debug("Duplicate unicode: {} in https://emojipedia.org/{} and https://emojipedia.org/{}, might not be grave", emoji.unicode(), old.subpage(), emoji.subpage());
 				}

--- a/src/main/java/com/freya02/emojis/Emojis.java
+++ b/src/main/java/com/freya02/emojis/Emojis.java
@@ -62,13 +62,23 @@ public class Emojis {
 
 		static {
 			for (Emoji emoji : store.getEmojis()) {
-				final Emoji old = unicodeMap.put(emoji.unicode(), emoji);
-				if (old != null) {
-					LOGGER.debug("Duplicate unicode: {} in https://emojipedia.org/{} and https://emojipedia.org/{}, might not be grave", emoji.unicode(), old.subpage(), emoji.subpage());
+				if (emoji.doesSupportFitzpatrick()) {
+					for (Fritzpatrick type : Fritzpatrick.values()) {
+						putEmojiInUnicodeMap(emoji.asFritzpatrick(type));
+					}
 				}
+
+				putEmojiInUnicodeMap(emoji);
 			}
 
 			LOGGER.debug("Loaded unicode map");
+		}
+
+		private static void putEmojiInUnicodeMap(Emoji emoji) {
+			final Emoji old = unicodeMap.put(emoji.unicode(), emoji);
+			if (old != null) {
+				LOGGER.debug("Duplicate unicode: {} in https://emojipedia.org/{} and https://emojipedia.org/{}, might not be grave", emoji.unicode(), old.subpage(), emoji.subpage());
+			}
 		}
 	}
 

--- a/src/main/java/com/freya02/emojis/Emojis.java
+++ b/src/main/java/com/freya02/emojis/Emojis.java
@@ -39,7 +39,15 @@ public class Emojis {
 	 * @return An {@link Emoji} with the matching unicode, or <code>null</code> if not found
 	 */
 	public static Emoji ofUnicode(String unicode) {
-		return UnicodeHolder.unicodeMap.get(unicode);
+		String unFritzedUnicode = unicode;
+		if (unicode.codePoints().count() > 0) {
+			for (Fritzpatrick fritz : Fritzpatrick.values()) {
+				unFritzedUnicode = unicode.replace(fritz.getUnicode(), "");
+				if (unFritzedUnicode.length() != unicode.length()) break;
+			}
+		}
+
+		return UnicodeHolder.unicodeMap.get(unFritzedUnicode);
 	}
 
 	/**
@@ -62,23 +70,13 @@ public class Emojis {
 
 		static {
 			for (Emoji emoji : store.getEmojis()) {
-				if (emoji.doesSupportFitzpatrick()) {
-					for (Fritzpatrick type : Fritzpatrick.values()) {
-						putEmojiInUnicodeMap(emoji.asFritzpatrick(type));
-					}
+				final Emoji old = unicodeMap.put(emoji.unicode(), emoji);
+				if (old != null) {
+					LOGGER.debug("Duplicate unicode: {} in https://emojipedia.org/{} and https://emojipedia.org/{}, might not be grave", emoji.unicode(), old.subpage(), emoji.subpage());
 				}
-
-				putEmojiInUnicodeMap(emoji);
 			}
 
 			LOGGER.debug("Loaded unicode map");
-		}
-
-		private static void putEmojiInUnicodeMap(Emoji emoji) {
-			final Emoji old = unicodeMap.put(emoji.unicode(), emoji);
-			if (old != null) {
-				LOGGER.debug("Duplicate unicode: {} in https://emojipedia.org/{} and https://emojipedia.org/{}, might not be grave", emoji.unicode(), old.subpage(), emoji.subpage());
-			}
 		}
 	}
 

--- a/src/main/java/com/freya02/emojis/Fritzpatrick.java
+++ b/src/main/java/com/freya02/emojis/Fritzpatrick.java
@@ -1,0 +1,20 @@
+package com.freya02.emojis;
+
+public enum Fritzpatrick {
+
+    LIGHT("\uD83C\uDFFB"),
+    MEDIUM_LIGHT("\uD83C\uDFFC"),
+    MEDIUM("\uD83C\uDFFD"),
+    MEDIUM_DARK("\uD83C\uDFFE"),
+    DARK("\uD83C\uDFFF");
+
+    private final String unicode;
+
+    Fritzpatrick(String unicode) {
+        this.unicode = unicode;
+    }
+
+    public String getUnicode() {
+        return unicode;
+    }
+}


### PR DESCRIPTION
This makes it possible to turn all discord unicode emoji into an emoji object by using `Emojis.ofUnicode(emoji)`

