### PR TITLE
Set the encoding for reading the emojis.json file explicitly

### DIFF
--- a/src/main/java/com/freya02/emojis/EmojiStore.java
+++ b/src/main/java/com/freya02/emojis/EmojiStore.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -25,7 +27,7 @@ public class EmojiStore {
 		LOGGER.debug("Loading local emojis");
 
 		final EmojiStore store;
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Utils.getResource("emojis.json")))) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Utils.getResource("emojis.json"), StandardCharsets.UTF_8))) {
 			store = GSON.fromJson(reader, EmojiStore.class);
 		}
 

--- a/src/main/java/com/freya02/emojis/EmojiStore.java
+++ b/src/main/java/com/freya02/emojis/EmojiStore.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
Instead of relying on the default encoding, which might break the Unicode emojis if it's not UTF-8, specify the encoding explicitly